### PR TITLE
Support aeson-1.* and servant >= 0.9

### DIFF
--- a/grakn.cabal
+++ b/grakn.cabal
@@ -24,7 +24,7 @@ library
                       , scientific  == 0.3.*
                       , text        == 1.2.*
                       , regex-posix == 0.95.*
-                      , servant     == 0.9.*
+                      , servant     >= 0.9
                       , servant-client
                       , http-client
                       , mtl
@@ -52,11 +52,11 @@ test-suite test
                       , grakn
                       , containers  == 0.5.*
                       , process     == 1.4.*
-                      , aeson       == 1.0.*
+                      , aeson       == 1.*
                       , scientific  == 0.3.*
                       , text        == 1.2.*
                       , regex-posix == 0.95.*
-                      , servant     == 0.9.*
+                      , servant     >= 0.9
                       , servant-client
                       , http-client
                       , mtl
@@ -82,11 +82,11 @@ test-suite accept
                       , grakn
                       , containers  == 0.5.*
                       , process     == 1.4.*
-                      , aeson       == 1.0.*
+                      , aeson       == 1.*
                       , scientific  == 0.3.*
                       , text        == 1.2.*
                       , regex-posix == 0.95.*
-                      , servant     == 0.9.*
+                      , servant     >= 0.9
                       , servant-client
                       , http-client
                       , mtl


### PR DESCRIPTION
grakn-0.2.0 currently [fails on hydra](https://hydra.nixos.org/build/60422279) because aeson and servant are newer than required by the cabal file. It would be great to get a release with this fixed.